### PR TITLE
feat: 댓글 작성/삭제/조회 기능 구현

### DIFF
--- a/src/main/java/backend/baba/comment/controller/CommentController.java
+++ b/src/main/java/backend/baba/comment/controller/CommentController.java
@@ -1,4 +1,41 @@
 package backend.baba.comment.controller;
 
+import backend.baba.comment.dto.CommentResponseDto;
+import backend.baba.comment.service.CommentService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/comment")
+@RequiredArgsConstructor
 public class CommentController {
+
+    private final CommentService commentService;
+
+    @PostMapping
+    public ResponseEntity<Void> createComment(
+            @RequestParam String username,
+            @RequestParam Long diaryId,
+            @RequestParam String content
+    ) {
+        commentService.createComment(username, diaryId, content);
+        return ResponseEntity.ok().build();
+    }
+
+    @DeleteMapping
+    public ResponseEntity<Void> deleteComment(
+            @RequestParam String username,
+            @RequestParam Long commentId
+    ) {
+        commentService.deleteComment(username, commentId);
+        return ResponseEntity.ok().build();
+    }
+
+    @GetMapping
+    public ResponseEntity<List<CommentResponseDto>> getComments(@RequestParam Long diaryId) {
+        return ResponseEntity.ok(commentService.getComments(diaryId));
+    }
 }

--- a/src/main/java/backend/baba/comment/domain/Comment.java
+++ b/src/main/java/backend/baba/comment/domain/Comment.java
@@ -1,16 +1,36 @@
 package backend.baba.comment.domain;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import lombok.Getter;
+import backend.baba.diary.domain.Diary;
+import backend.baba.member.domain.Member;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDateTime;
 
 @Entity
 @Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
 public class Comment {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
+    @Column(nullable = false)
+    private String content;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "diary_id")
+    private Diary diary;
+
+    @CreationTimestamp
+    @Column(updatable = false)
+    private LocalDateTime createdAt;
 }

--- a/src/main/java/backend/baba/comment/dto/CommentResponseDto.java
+++ b/src/main/java/backend/baba/comment/dto/CommentResponseDto.java
@@ -1,0 +1,25 @@
+package backend.baba.comment.dto;
+
+import backend.baba.comment.domain.Comment;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class CommentResponseDto {
+    private Long id;
+    private String content;
+    private String username;
+    private LocalDateTime createdAt;
+
+    public static CommentResponseDto fromEntity(Comment comment) {
+        return CommentResponseDto.builder()
+                .id(comment.getId())
+                .content(comment.getContent())
+                .username(comment.getMember().getUsername())
+                .createdAt(comment.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/backend/baba/comment/repository/CommentRepository.java
+++ b/src/main/java/backend/baba/comment/repository/CommentRepository.java
@@ -1,4 +1,15 @@
 package backend.baba.comment.repository;
 
-public class CommentRepository {
+import backend.baba.comment.domain.Comment;
+import backend.baba.diary.domain.Diary;
+import backend.baba.member.domain.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+    List<Comment> findByDiaryOrderByCreatedAtAsc(Diary diary);
+    Optional<Comment> findByIdAndMember(Long id, Member member);
 }
+

--- a/src/main/java/backend/baba/comment/service/CommentService.java
+++ b/src/main/java/backend/baba/comment/service/CommentService.java
@@ -1,4 +1,68 @@
 package backend.baba.comment.service;
 
+import backend.baba.comment.domain.Comment;
+import backend.baba.comment.dto.CommentResponseDto;
+import backend.baba.comment.repository.CommentRepository;
+import backend.baba.diary.domain.Diary;
+import backend.baba.diary.repository.DiaryRepository;
+import backend.baba.member.domain.Member;
+import backend.baba.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
 public class CommentService {
+
+    private final CommentRepository commentRepository;
+    private final MemberRepository memberRepository;
+    private final DiaryRepository diaryRepository;
+
+    // 댓글 작성
+    @Transactional
+    public void createComment(String username, Long diaryId, String content) {
+        Member member = memberRepository.findByUsername(username)
+                .orElseThrow(() -> new IllegalArgumentException("유저가 존재하지 않습니다."));
+        Diary diary = diaryRepository.findById(diaryId)
+                .orElseThrow(() -> new IllegalArgumentException("기록이 존재하지 않습니다."));
+
+        Comment comment = Comment.builder()
+                .content(content)
+                .member(member)
+                .diary(diary)
+                .build();
+
+        commentRepository.save(comment);
+        diary.setCommentCount(diary.getCommentCount() + 1);
+    }
+
+    // 댓글 삭제
+    @Transactional
+    public void deleteComment(String username, Long commentId) {
+        Member member = memberRepository.findByUsername(username)
+                .orElseThrow(() -> new IllegalArgumentException("유저가 존재하지 않습니다."));
+
+        Comment comment = commentRepository.findByIdAndMember(commentId, member)
+                .orElseThrow(() -> new IllegalArgumentException("댓글이 존재하지 않거나 삭제 권한이 없습니다."));
+
+        commentRepository.delete(comment);
+        Diary diary = comment.getDiary();
+        diary.setCommentCount(Math.max(diary.getCommentCount() - 1, 0));  // 음수 방지
+    }
+
+     // 특정 기록(Diary)에 달린 댓글들 조회
+    @Transactional(readOnly = true)
+    public List<CommentResponseDto> getComments(Long diaryId) {
+
+        Diary diary = diaryRepository.findById(diaryId)
+                .orElseThrow(() -> new IllegalArgumentException("기록이 존재하지 않습니다."));
+
+        return commentRepository.findByDiaryOrderByCreatedAtAsc(diary).stream()
+                .map(CommentResponseDto::fromEntity)
+                .collect(Collectors.toList());
+    }
 }

--- a/src/main/java/backend/baba/diary/domain/Diary.java
+++ b/src/main/java/backend/baba/diary/domain/Diary.java
@@ -68,5 +68,7 @@ public class Diary {
         this.loveCount = loveCount;
     }
 
-
+    public void setCommentCount(int commentCount) {
+        this.commentCount = commentCount;
+    }
 }


### PR DESCRIPTION
## 📑 PR 요약
- 댓글 작성: 댓글 저장 + 다이어리의 commentCount 증가
- 댓글 삭제: 본인 댓글만 삭제 가능 + 다이어리의 commentCount 감소
- 댓글 조회: 작성 시간 오름차순 정렬
- 예외 처리

## 🔗 관련 이슈
#41 

## ☑ 작업 내용

## 📣 공유사항
<!-- PR과 관련된 내용 공유나 reviewer에 대한 요청사항이 있다면 작성해주세요. -->
